### PR TITLE
Update install.yml

### DIFF
--- a/provisioning/roles/ANXS.postgresql/tasks/install.yml
+++ b/provisioning/roles/ANXS.postgresql/tasks/install.yml
@@ -21,7 +21,7 @@
   apt:
     name: "{{item}}"
     state: present
-  environment: postgresql_env
+  environment: "{{postgresql_env}}"
   with_items:
     - "postgresql-{{postgresql_version}}"
     - "postgresql-client-{{postgresql_version}}"


### PR DESCRIPTION
[DEPRECATION WARNING]: Using bare variables for environment is deprecated. Update your playbooks so that the environment value uses the full 
variable syntax ('{{foo}}'). This feature will be removed in a future release. Deprecation warnings can be disabled by setting 
deprecation_warnings=False in ansible.cfg.
fatal: [localhost]: FAILED! => {"failed": true, "msg": "ERROR! environment must be a dictionary, received postgresql_env (<class 'ansible.parsing.yaml.objects.AnsibleUnicode'>)"}