### PR TITLE
Update rubies.yml

### DIFF
--- a/provisioning/roles/rvm_io.ruby/tasks/rubies.yml
+++ b/provisioning/roles/rvm_io.ruby/tasks/rubies.yml
@@ -29,7 +29,7 @@
   with_items: '{{ rvm1_rubies }}'
   changed_when: False
   register: ruby_patch
-  check_mode: no # Run in normal mode when in --check mode (http://docs.ansible.com/ansible/playbooks_checkmode.html)
+  #check_mode: no # Run in normal mode when in --check mode (http://docs.ansible.com/ansible/playbooks_checkmode.html)
 
 - name: Install bundler if not installed
   shell: >


### PR DESCRIPTION
fatal: [localhost]: FAILED! => {"failed": true, "reason": "ERROR! 'check_mode' is not a valid attribute for a Task\n\nThe error appears to have been in '/vagrant/cuttlefish/provisioning/roles/rvm_io.ruby/tasks/rubies.yml': line 26, column 3, but may\nbe elsewhere in the file depending on the exact syntax problem.\n\nThe offending line appears to be:\n\n\n- name: Detect installed ruby patch number\n  ^ here\n"}